### PR TITLE
Update data.py

### DIFF
--- a/obplayer/data.py
+++ b/obplayer/data.py
@@ -753,6 +753,6 @@ class ObConfigData(ObData):
     def list_settings(self, hidepasswords=False):
         result = {}
         for name, value in self.settings_cache.items():
-            if not hidepasswords or not name.endswith("_password"):
+            if not hidepasswords or not name.endswith('_password') and not name.endswith('_access_key') and not name.endswith('_access_key_id'):
                 result[name] = value
         return result

--- a/obplayer/data.py
+++ b/obplayer/data.py
@@ -754,10 +754,10 @@ class ObConfigData(ObData):
         result = {}
         for name, value in self.settings_cache.items():
             if (
-    not hidepasswords
-    or not name.endswith("_password")
-    and not name.endswith("_access_key")
-    and not name.endswith("_access_key_id")
+        not hidepasswords
+        or not name.endswith("_password")
+        and not name.endswith("_access_key")
+        and not name.endswith("_access_key_id")
     ):
                 result[name] = value
         return result

--- a/obplayer/data.py
+++ b/obplayer/data.py
@@ -753,6 +753,11 @@ class ObConfigData(ObData):
     def list_settings(self, hidepasswords=False):
         result = {}
         for name, value in self.settings_cache.items():
-            if not hidepasswords or not name.endswith('_password') and not name.endswith('_access_key') and not name.endswith('_access_key_id'):
+            if (
+    not hidepasswords
+    or not name.endswith("_password")
+    and not name.endswith("_access_key")
+    and not name.endswith("_access_key_id")
+    ):
                 result[name] = value
         return result


### PR DESCRIPTION
# OB Description
(Copy of main  pull request to dev branch)
This pull request is in response to this ongoing issue: https://github.com/openbroadcaster/obplayer/issues/138
It is a very simple change to the `list_settings` function in  `data.py`, that adds new conditions to filter out the AWS secrets from being exported to the config file.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 
- [ ] This change requires a documentation update 

## How Has This Been Tested?
Yes, I ran the obplayer software twice and the issue of AWS secrets being in the config file were not present.

## Testing Environments
OpenBroadcaster Component  and Version
- [ ] OBServer 
- [X] OBPlayer 
- [ ] Module
- [ ] Other

## Browser Version?
- [ ] Chrome
- [X] Edge 139.0.3405.125 (Official build) (64-bit)
- [ ] Firefox
- [ ] Safari
- [ ] Other

## OS Version?
- [ ] BSD
- [ ] Debian
- [ ] Raspberry OS
- [X] Ubuntu 24.04.1 (LTS)
- [ ] Other

## Checklist:
- [X] My code follows the style guidelines of this project 
- [X] I have performed a self-review of my own code and corrected any misspellings
- [X] I have commented my code, particularly in hard-to-understand areas 
- [X] I have made corresponding changes to the documentation 
- [X] My changes generate no new warnings 
- [X] I have added tests that prove my fix is effective or that my feature works 
- [X] New and existing unit tests pass locally with my changes

Thanks for contributing!
